### PR TITLE
add serialization for `BgpElem`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"
@@ -20,3 +20,4 @@ num-traits = "0.2"
 log = "0.4"
 ipnetwork = {version="0.18", default-features=false}
 itertools = "0.10.1"
+serde={version="1", features=["derive"]}

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use itertools::Itertools;
 use crate::network::*;
+use serde::{Serialize, Serializer};
 
 /// The high-order bit (bit 0) of the Attribute Flags octet is the
 /// Optional bit.  It defines whether the attribute is optional (if
@@ -408,7 +409,33 @@ impl Display for AsPath {
     }
 }
 
+///////////////
+// SERIALIZE //
+///////////////
 
+impl Serialize for AsPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl Serialize for Origin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl Serialize for Community {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl Serialize for AtomicAggregate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -4,12 +4,13 @@ use std::str::FromStr;
 use itertools::Itertools;
 use crate::bgp::attributes::{AsPath, AtomicAggregate, Community, Origin};
 use crate::network::{Asn, NetworkPrefix};
+use serde::Serialize;
 
 /// Element type.
 ///
 /// - ANNOUNCE: announcement/reachable prefix
 /// - WITHDRAW: withdrawn/unreachable prefix
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub enum ElemType {
     ANNOUNCE,
     WITHDRAW,
@@ -21,7 +22,7 @@ pub enum ElemType {
 ///
 /// Note: it consumes more memory to construct BGP elements due to duplicate information
 /// shared between multiple elements of one MRT record.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BgpElem {
     pub timestamp: f64,
     pub elem_type: ElemType,

--- a/src/network.rs
+++ b/src/network.rs
@@ -4,6 +4,7 @@ use std::fmt::{Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 use ipnetwork::IpNetwork;
+use serde::{Serialize, Serializer};
 use crate::err::BgpModelsError;
 
 /// Meta information for an address/prefix.
@@ -64,6 +65,12 @@ pub enum NextHopAddress {
 pub struct NetworkPrefix {
     pub prefix: IpNetwork,
     pub path_id: u32,
+}
+
+impl Serialize for NetworkPrefix {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
 }
 
 impl FromStr for NetworkPrefix {


### PR DESCRIPTION
Added `Serialize` for `BgpElem`, allowing downstream consumers to more easily serialize messages without needing to write custom serialization functions.