### PR TITLE
Add extended community support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.4.1"
+version = "0.5.0-rc.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.5.0-rc.2"
+version = "0.5.0-rc.3"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -2,11 +2,53 @@
 
 [![Rust](https://github.com/bgpkit/bgp-models/actions/workflows/rust.yml/badge.svg)](https://github.com/bgpkit/bgp-models/actions/workflows/rust.yml)
 
-Structs and other building blocks for BGP and MRT related Rust projects.
+`bgp-models` is a library that defines the basic BGP and MRT message data structures.
+This library aims to provide building blocks for downstreams libraries working with BGP and MRT
+messages such as MRT parser or BGP table constructor.
+
+## Supported RFCs
+
+Most of the structs defined in this library are named after the formal definitions in a number of
+RFCs. Here is a list of them:
+
+### BGP
+- [X] [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271): A Border Gateway Protocol 4 (BGP-4)
+- [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
+
+### MRT
+
+- [X] [RFC 6396](https://datatracker.ietf.org/doc/html/rfc6396): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format
+- [ ] [RFC 6397](https://datatracker.ietf.org/doc/html/rfc6397): Multi-Threaded Routing Toolkit (MRT) Border Gateway Protocol (BGP) Routing Information Export Format with Geo-Location Extensions
+- [X] [RFC 8050](https://datatracker.ietf.org/doc/html/rfc8050): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format with BGP Additional Path Extensions
+
+### Communities
+
+#### Communities
+
+- [X] [RFC 1977](https://datatracker.ietf.org/doc/html/rfc1977): BGP Communities Attribute
+
+#### Extended Communities
+
+- [X] [RFC 4360](https://datatracker.ietf.org/doc/html/rfc4360): BGP Extended Communities Attribute
+- [X] [RFC 5668](https://datatracker.ietf.org/doc/html/rfc5668): 4-Octet AS Specific BGP Extended Community
+- [X] [RFC 5701](https://datatracker.ietf.org/doc/html/rfc5701): IPv6 Address Specific BGP Extended Community Attribute
+- [X] [RFC 7153](https://datatracker.ietf.org/doc/html/rfc7153): IANA Registries for BGP Extended Communities Updates 4360, 5701
+- [X] [RFC 8097](https://datatracker.ietf.org/doc/html/rfc8097): BGP Prefix Origin Validation State Extended Community
+
+#### Large Communities
+
+- [X] [RFC 8092](https://datatracker.ietf.org/doc/html/rfc8092): BGP Large Communities
+
+#### Other Informational
+
+- [RFC 4384](https://datatracker.ietf.org/doc/html/rfc4384): BGP Communities for Data Collection BCP 114
+- [RFC 8195](https://datatracker.ietf.org/doc/html/rfc8195): Use of BGP Large Communities (informational)
+- [RFC 8642](https://datatracker.ietf.org/doc/html/rfc8642): Policy Behavior for Well-Known BGP Communities
 
 ## Used By
 
 - [bgpkit-parser](https://github.com/bgpkit/bgpkit-parser)
+- [ris-live-rs](https://github.com/bgpkit/ris-live-rs)
 
 ## Built with ❤️ by BGPKIT Team
 

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -1,0 +1,229 @@
+use enum_primitive_derive::Primitive;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use serde::Serialize;
+use crate::network::Asn;
+
+/////////////////
+// COMMUNITIES //
+/////////////////
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Community {
+    NoExport,
+    NoAdvertise,
+    NoExportSubConfed,
+    Custom(Asn, u16),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct LargeCommunity {
+    global_administrator: u32,
+    local_data: [u32; 2],
+}
+
+impl LargeCommunity {
+    pub fn new(global_administrator: u32, local_data: [u32; 2]) -> LargeCommunity {
+        LargeCommunity {
+            global_administrator,
+            local_data,
+        }
+    }
+}
+
+/// Type definitions of extended communities
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum ExtendedCommunityType {
+    // transitive types
+
+    TransitiveTwoOctetAsSpecific = 0x00,
+    TransitiveIpv4AddressSpecific = 0x01,
+    TransitiveFourOctetAsSpecific = 0x02,
+    TransitiveOpaque = 0x03,
+
+    // non-transitive types
+
+    NonTransitiveTwoOctetAsSpecific = 0x40,
+    NonTransitiveIpv4AddressSpecific = 0x41,
+    NonTransitiveFourOctetAsSpecific = 0x42,
+    NonTransitiveOpaque = 0x43,
+
+    // the rest are either draft or experimental
+}
+
+/// Extended Communities.
+///
+/// It is a 8-octet data that has flexible definition based on the types:
+/// <https://datatracker.ietf.org/doc/html/rfc4360>
+///
+/// For more up-to-date definitions, see [IANA' website](https://www.iana.org/assignments/bgp-extended-communities/bgp-extended-communities.xhtml#e-tree-flags).
+///
+/// ```text
+///    Each Extended Community is encoded as an 8-octet quantity, as
+///    follows:
+///
+///       - Type Field  : 1 or 2 octets
+///       - Value Field : Remaining octets
+///
+///        0                   1                   2                   3
+///        0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+///       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///       |  Type high    |  Type low(*)  |                               |
+///       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+          Value                |
+///       |                                                               |
+///       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+///       (*) Present for Extended types only, used for the Value field
+///           otherwise.
+/// ```
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ExtendedCommunity {
+    TransitiveTwoOctetAsSpecific(TwoOctetAsSpecific),
+    TransitiveIpv4AddressSpecific(Ipv4AddressSpecific),
+    TransitiveFourOctetAsSpecific(FourOctetAsSpecific),
+    TransitiveOpaque(Opaque),
+    NonTransitiveTwoOctetAsSpecific(TwoOctetAsSpecific),
+    NonTransitiveIpv4AddressSpecific(Ipv4AddressSpecific),
+    NonTransitiveFourOctetAsSpecific(FourOctetAsSpecific),
+    NonTransitiveOpaque(Opaque),
+    Raw([u8; 8]),
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Ipv6AddressSpecificExtendedCommunity {
+    ec_type: u8,
+    ec_subtype: u8,
+    // 16 octets
+    global_administrator: Ipv6Addr,
+    // 2 octets
+    local_administrator: [u8; 2]
+}
+
+
+/// Two-Octet AS Specific Extended Community
+///
+/// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.1>
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct TwoOctetAsSpecific {
+    ec_type: u8,
+    ec_subtype: u8,
+    // 2 octet
+    global_administrator: Asn,
+    // 4 octet
+    local_administrator: [u8; 4],
+}
+
+/// Four-Octet AS Specific Extended Community
+///
+/// <https://datatracker.ietf.org/doc/html/rfc5668#section-2>
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct FourOctetAsSpecific {
+    ec_type: u8,
+    ec_subtype: u8,
+    // 4 octet
+    global_administrator: Asn,
+    // 2 octet
+    local_administrator: [u8; 2],
+}
+
+/// IPv4 Address Specific Extended Community
+///
+/// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.2>
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Ipv4AddressSpecific {
+    ec_type: u8,
+    ec_subtype: u8,
+    // 4 octet
+    global_administrator: Ipv4Addr,
+    // 2 octet
+    local_administrator: [u8; 4],
+}
+
+/// Opaque Extended Community
+///
+/// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.3>
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Opaque {
+    ec_type: u8,
+    ec_subtype: u8,
+    // 6 octet
+    value: [u8; 6],
+}
+
+fn bytes_to_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|x| format!("{:02X}", x)).collect::<Vec<String>>().join("")
+}
+
+impl Serialize for Community {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl std::fmt::Display for Community {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            Community::NoExport => {
+                "no-export".to_string()
+            }
+            Community::NoAdvertise => {
+                "no-advertise".to_string()
+            }
+            Community::NoExportSubConfed => {
+                "no-export-sub-confed".to_string()
+            }
+            Community::Custom(asn, value) => {
+                format!("{}:{}", asn, value)
+            }
+        }
+        )
+    }
+}
+
+impl Serialize for ExtendedCommunity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl Serialize for LargeCommunity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: serde::Serializer {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl std::fmt::Display for LargeCommunity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}:{}", self.global_administrator, self.local_data[0], self.local_data[1])
+    }
+}
+
+impl std::fmt::Display for Ipv6AddressSpecificExtendedCommunity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}:{}:{}", self.ec_type, self.ec_subtype, self.global_administrator, bytes_to_string(&self.local_administrator))
+    }
+}
+
+impl std::fmt::Display for ExtendedCommunity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ExtendedCommunity::TransitiveTwoOctetAsSpecific(ec) | ExtendedCommunity::NonTransitiveTwoOctetAsSpecific(ec) => {
+                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+            }
+            ExtendedCommunity::TransitiveIpv4AddressSpecific(ec) |
+            ExtendedCommunity::NonTransitiveIpv4AddressSpecific(ec) => {
+                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+            }
+            ExtendedCommunity::TransitiveFourOctetAsSpecific(ec) |
+            ExtendedCommunity::NonTransitiveFourOctetAsSpecific(ec) => {
+                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+            }
+            ExtendedCommunity::TransitiveOpaque(ec) |
+            ExtendedCommunity::NonTransitiveOpaque(ec) => {
+                format!("{}:{}:{}", ec.ec_type, ec.ec_subtype, bytes_to_string(&ec.value))
+            }
+            ExtendedCommunity::Raw(ec) => {
+                format!("{}", bytes_to_string(ec))
+            }
+        })
+    }
+}

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -131,7 +131,7 @@ pub struct Ipv4AddressSpecific {
     // 4 octet
     pub global_administrator: Ipv4Addr,
     // 2 octet
-    pub local_administrator: [u8; 4],
+    pub local_administrator: [u8; 2],
 }
 
 /// Opaque Extended Community

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -3,10 +3,6 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use serde::Serialize;
 use crate::network::Asn;
 
-/////////////////
-// COMMUNITIES //
-/////////////////
-
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Community {
     NoExport,

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -13,8 +13,8 @@ pub enum Community {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct LargeCommunity {
-    global_administrator: u32,
-    local_data: [u32; 2],
+    pub global_administrator: u32,
+    pub local_data: [u32; 2],
 }
 
 impl LargeCommunity {
@@ -86,12 +86,12 @@ pub enum ExtendedCommunity {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Ipv6AddressSpecificExtendedCommunity {
-    ec_type: u8,
-    ec_subtype: u8,
+    pub ec_type: u8,
+    pub ec_subtype: u8,
     // 16 octets
-    global_administrator: Ipv6Addr,
+    pub global_administrator: Ipv6Addr,
     // 2 octets
-    local_administrator: [u8; 2]
+    pub local_administrator: [u8; 2]
 }
 
 
@@ -100,12 +100,12 @@ pub struct Ipv6AddressSpecificExtendedCommunity {
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.1>
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct TwoOctetAsSpecific {
-    ec_type: u8,
-    ec_subtype: u8,
+    pub ec_type: u8,
+    pub ec_subtype: u8,
     // 2 octet
-    global_administrator: Asn,
+    pub global_administrator: Asn,
     // 4 octet
-    local_administrator: [u8; 4],
+    pub local_administrator: [u8; 4],
 }
 
 /// Four-Octet AS Specific Extended Community
@@ -113,12 +113,12 @@ pub struct TwoOctetAsSpecific {
 /// <https://datatracker.ietf.org/doc/html/rfc5668#section-2>
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct FourOctetAsSpecific {
-    ec_type: u8,
-    ec_subtype: u8,
+    pub ec_type: u8,
+    pub ec_subtype: u8,
     // 4 octet
-    global_administrator: Asn,
+    pub global_administrator: Asn,
     // 2 octet
-    local_administrator: [u8; 2],
+    pub local_administrator: [u8; 2],
 }
 
 /// IPv4 Address Specific Extended Community
@@ -126,12 +126,12 @@ pub struct FourOctetAsSpecific {
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.2>
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Ipv4AddressSpecific {
-    ec_type: u8,
-    ec_subtype: u8,
+    pub ec_type: u8,
+    pub ec_subtype: u8,
     // 4 octet
-    global_administrator: Ipv4Addr,
+    pub global_administrator: Ipv4Addr,
     // 2 octet
-    local_administrator: [u8; 4],
+    pub local_administrator: [u8; 4],
 }
 
 /// Opaque Extended Community
@@ -139,10 +139,10 @@ pub struct Ipv4AddressSpecific {
 /// <https://datatracker.ietf.org/doc/html/rfc4360#section-3.3>
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Opaque {
-    ec_type: u8,
-    ec_subtype: u8,
+    pub ec_type: u8,
+    pub ec_subtype: u8,
     // 6 octet
-    value: [u8; 6],
+    pub value: [u8; 6],
 }
 
 fn bytes_to_string(bytes: &[u8]) -> String {

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -2,7 +2,8 @@ use std::fmt::{Display, Formatter};
 use std::net::IpAddr;
 use std::str::FromStr;
 use itertools::Itertools;
-use crate::bgp::attributes::{AsPath, AtomicAggregate, Community, Origin};
+use crate::bgp::attributes::{AsPath, AtomicAggregate, Origin};
+use crate::bgp::community::*;
 use crate::network::{Asn, NetworkPrefix};
 use serde::Serialize;
 

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod attributes;
 pub mod elem;
+pub mod community;
 
 pub use crate::bgp::attributes::*;
 pub use crate::bgp::elem::*;

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -6,6 +6,7 @@ pub mod community;
 
 pub use crate::bgp::attributes::*;
 pub use crate::bgp::elem::*;
+pub use crate::bgp::community::*;
 
 use std::net::Ipv4Addr;
 use crate::network::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,45 @@
 This library aims to provide building blocks for downstreams libraries working with BGP and MRT
 messages such as MRT parser or BGP table constructor.
 
+## Supported RFCs
+
 Most of the structs defined in this library are named after the formal definitions in a number of
 RFCs. Here is a list of them:
 
-- [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271): A Border Gateway Protocol 4 (BGP-4)
-- [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
-- [RFC 6396](https://datatracker.ietf.org/doc/html/rfc6396): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format
-- [RFC 8050](https://datatracker.ietf.org/doc/html/rfc8050): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format with BGP Additional Path Extensions
+### BGP
+- [X] [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271): A Border Gateway Protocol 4 (BGP-4)
+- [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
+
+### MRT
+
+- [X] [RFC 6396](https://datatracker.ietf.org/doc/html/rfc6396): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format
+- [ ] [RFC 6397](https://datatracker.ietf.org/doc/html/rfc6397): Multi-Threaded Routing Toolkit (MRT) Border Gateway Protocol (BGP) Routing Information Export Format with Geo-Location Extensions
+- [X] [RFC 8050](https://datatracker.ietf.org/doc/html/rfc8050): Multi-Threaded Routing Toolkit (MRT) Routing Information Export Format with BGP Additional Path Extensions
+
+### Communities
+
+#### Communities
+
+- [X] [RFC 1977](https://datatracker.ietf.org/doc/html/rfc1977): BGP Communities Attribute
+
+#### Extended Communities
+
+- [X] [RFC 4360](https://datatracker.ietf.org/doc/html/rfc4360): BGP Extended Communities Attribute
+- [X] [RFC 5668](https://datatracker.ietf.org/doc/html/rfc5668): 4-Octet AS Specific BGP Extended Community
+- [X] [RFC 5701](https://datatracker.ietf.org/doc/html/rfc5701): IPv6 Address Specific BGP Extended Community Attribute
+- [X] [RFC 7153](https://datatracker.ietf.org/doc/html/rfc7153): IANA Registries for BGP Extended Communities Updates 4360, 5701
+- [X] [RFC 8097](https://datatracker.ietf.org/doc/html/rfc8097): BGP Prefix Origin Validation State Extended Community
+
+#### Large Communities
+
+- [X] [RFC 8092](https://datatracker.ietf.org/doc/html/rfc8092): BGP Large Communities
+
+### Other Informational
+
+- [RFC 4384](https://datatracker.ietf.org/doc/html/rfc4384): BGP Communities for Data Collection BCP 114
+- [RFC 8195](https://datatracker.ietf.org/doc/html/rfc8195): Use of BGP Large Communities (informational)
+- [RFC 8642](https://datatracker.ietf.org/doc/html/rfc8642): Policy Behavior for Well-Known BGP Communities
+
  */
 
 #![allow(dead_code)]


### PR DESCRIPTION
Add extended community attributes support.

Relevant RFCs:
- [X] [RFC 4360](https://datatracker.ietf.org/doc/html/rfc4360): BGP Extended Communities Attribute
- [X] [RFC 5668](https://datatracker.ietf.org/doc/html/rfc5668): 4-Octet AS Specific BGP Extended Community
- [X] [RFC 5701](https://datatracker.ietf.org/doc/html/rfc5701): IPv6 Address Specific BGP Extended Community Attribute
- [X] [RFC 7153](https://datatracker.ietf.org/doc/html/rfc7153): IANA Registries for BGP Extended Communities Updates 4360, 5701
- [X] [RFC 8097](https://datatracker.ietf.org/doc/html/rfc8097): BGP Prefix Origin Validation State Extended Community