### PR TITLE
Serialization, Attributes simplification, Communities serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.6.0-rc.2"
+version = "0.6.0-rc.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.5.0"
+version = "0.6.0-rc.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -99,6 +99,7 @@ pub enum AtomicAggregate {
 
 /// The `Attribute` enum represents different kinds of Attribute values.
 #[derive(Debug, PartialEq, Clone, Serialize)]
+#[serde(untagged)]
 pub enum Attribute {
     Origin(Origin),
     AsPath(AsPath),

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -45,7 +45,7 @@ pub enum AttributeFlagsBit {
 /// To see the full list, check out IANA at:
 /// <https://www.iana.org/assignments/bgp-parameters/bgp-parameters.xhtml#bgp-parameters-2>
 #[allow(non_camel_case_types)]
-#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, Primitive, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
 pub enum AttrType {
     RESERVED = 0,
     ORIGIN = 1,
@@ -98,7 +98,7 @@ pub enum AtomicAggregate {
 }
 
 /// The `Attribute` enum represents different kinds of Attribute values.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum Attribute {
     Origin(Origin),
     AsPath(AsPath),
@@ -240,7 +240,7 @@ impl AsPath {
 // NLRI //
 //////////
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct Nlri {
     pub afi: Afi,
     pub safi: Safi,
@@ -248,7 +248,7 @@ pub struct Nlri {
     pub prefixes: Vec<NetworkPrefix>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct MpReachableNlri {
     afi: Afi,
     safi: Safi,

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -112,7 +112,8 @@ pub enum Attribute {
     LargeCommunities(Vec<LargeCommunity>),
     OriginatorId(IpAddr),
     Clusters(Vec<IpAddr>),
-    Nlri(Nlri),
+    MpReachNlri(Nlri),
+    MpUnreachNlri(Nlri),
 }
 
 /////////////

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use itertools::Itertools;
 use crate::network::*;
 use serde::{Serialize, Serializer};
-use crate::bgp::community::Community;
+use crate::bgp::{ExtendedCommunity, LargeCommunity, Community};
 
 /// The high-order bit (bit 0) of the Attribute Flags octet is the
 /// Optional bit.  It defines whether the attribute is optional (if
@@ -99,7 +99,6 @@ pub enum AtomicAggregate {
 
 /// The `Attribute` enum represents different kinds of Attribute values.
 #[derive(Debug, PartialEq, Clone, Serialize)]
-#[serde(untagged)]
 pub enum Attribute {
     Origin(Origin),
     AsPath(AsPath),
@@ -109,15 +108,12 @@ pub enum Attribute {
     AtomicAggregate(AtomicAggregate),
     Aggregator(Asn, IpAddr),
     Communities(Vec<Community>),
+    ExtendedCommunities(Vec<ExtendedCommunity>),
+    LargeCommunities(Vec<LargeCommunity>),
     OriginatorId(IpAddr),
     Clusters(Vec<IpAddr>),
     Nlri(Nlri),
 }
-
-/// Type `Attributes` represents a vector of (AttrType, Attribute) pairs.
-///
-/// Note that we do not choose to use HashMap due to its inefficiency.
-pub type Attributes = Vec<(AttrType, Attribute)>;
 
 /////////////
 // AS PATH //

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -102,6 +102,7 @@ pub enum AtomicAggregate {
 pub enum Attribute {
     Origin(Origin),
     AsPath(AsPath),
+    As4Path(AsPath),
     NextHop(IpAddr),
     MultiExitDiscriminator(u32),
     LocalPreference(u32),

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use itertools::Itertools;
 use crate::network::*;
 use serde::{Serialize, Serializer};
-use crate::bgp::community::{Community, ExtendedCommunity, Ipv6AddressSpecificExtendedCommunity, LargeCommunity};
+use crate::bgp::community::Community;
 
 /// The high-order bit (bit 0) of the Attribute Flags octet is the
 /// Optional bit.  It defines whether the attribute is optional (if
@@ -108,9 +108,6 @@ pub enum Attribute {
     AtomicAggregate(AtomicAggregate),
     Aggregator(Asn, IpAddr),
     Communities(Vec<Community>),
-    LargeCommunities(Vec<LargeCommunity>),
-    ExtendedCommunity(Vec<ExtendedCommunity>),
-    IPv6AddressSpecificExtendedCommunity(Vec<Ipv6AddressSpecificExtendedCommunity>),
     OriginatorId(IpAddr),
     Clusters(Vec<IpAddr>),
     Nlri(Nlri),

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -1,7 +1,15 @@
+use std::fmt::Formatter;
 use enum_primitive_derive::Primitive;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use serde::Serialize;
 use crate::network::Asn;
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum MetaCommunity {
+    Community(Community),
+    ExtendedCommunity(ExtendedCommunity),
+    LargeCommunity(LargeCommunity),
+}
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Community {
@@ -177,7 +185,7 @@ impl std::fmt::Display for Community {
 
 impl std::fmt::Display for LargeCommunity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}:{}", self.global_administrator, self.local_data[0], self.local_data[1])
+        write!(f, "lg:{}:{}:{}", self.global_administrator, self.local_data[0], self.local_data[1])
     }
 }
 
@@ -185,27 +193,39 @@ impl std::fmt::Display for ExtendedCommunity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
             ExtendedCommunity::TransitiveTwoOctetAsSpecific(ec) | ExtendedCommunity::NonTransitiveTwoOctetAsSpecific(ec) => {
-                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+                format!("ecas2:{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
             }
             ExtendedCommunity::TransitiveIpv4AddressSpecific(ec) |
             ExtendedCommunity::NonTransitiveIpv4AddressSpecific(ec) => {
-                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+                format!("ecv4:{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
             }
             ExtendedCommunity::TransitiveFourOctetAsSpecific(ec) |
             ExtendedCommunity::NonTransitiveFourOctetAsSpecific(ec) => {
-                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+                format!("ecas4:{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
             }
             ExtendedCommunity::TransitiveOpaque(ec) |
             ExtendedCommunity::NonTransitiveOpaque(ec) => {
-                format!("{}:{}:{}", ec.ec_type, ec.ec_subtype, bytes_to_string(&ec.value))
+                format!("ecop:{}:{}:{}", ec.ec_type, ec.ec_subtype, bytes_to_string(&ec.value))
             }
             ExtendedCommunity::Ipv6AddressSpecific(ec) => {
-                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+                format!("ecv6:{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
             }
             ExtendedCommunity::Raw(ec) => {
-                format!("{}", bytes_to_string(ec))
+                format!("ecraw:{}", bytes_to_string(ec))
             }
         })
+    }
+}
+
+impl std::fmt::Display for MetaCommunity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}",
+            match self {
+                MetaCommunity::Community(c) => {c.to_string()}
+                MetaCommunity::ExtendedCommunity(c) => {c.to_string()}
+                MetaCommunity::LargeCommunity(c) => {c.to_string()}
+            }
+        )
     }
 }
 
@@ -226,3 +246,4 @@ macro_rules! impl_serialize {
 impl_serialize!(Community);
 impl_serialize!(ExtendedCommunity);
 impl_serialize!(LargeCommunity);
+impl_serialize!(MetaCommunity);

--- a/src/bgp/community.rs
+++ b/src/bgp/community.rs
@@ -1,4 +1,3 @@
-use std::fmt::Formatter;
 use enum_primitive_derive::Primitive;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use serde::Serialize;
@@ -6,14 +5,6 @@ use crate::network::Asn;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Community {
-    RegularCommunity(RegularCommunity),
-    ExtendedCommunity(ExtendedCommunity),
-    Ipv6SpecificExtendedCommunity(Ipv6AddressSpecificExtendedCommunity),
-    LargeCommunity(LargeCommunity),
-}
-
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum RegularCommunity {
     NoExport,
     NoAdvertise,
     NoExportSubConfed,
@@ -90,11 +81,12 @@ pub enum ExtendedCommunity {
     NonTransitiveIpv4AddressSpecific(Ipv4AddressSpecific),
     NonTransitiveFourOctetAsSpecific(FourOctetAsSpecific),
     NonTransitiveOpaque(Opaque),
+    Ipv6AddressSpecific(Ipv6AddressSpecific),
     Raw([u8; 8]),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
-pub struct Ipv6AddressSpecificExtendedCommunity {
+pub struct Ipv6AddressSpecific {
     pub ec_type: u8,
     pub ec_subtype: u8,
     // 16 octets
@@ -163,25 +155,19 @@ fn bytes_to_string(bytes: &[u8]) -> String {
 }
 
 
-impl std::fmt::Display for Ipv6AddressSpecificExtendedCommunity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}:{}:{}", self.ec_type, self.ec_subtype, self.global_administrator, bytes_to_string(&self.local_administrator))
-    }
-}
-
-impl std::fmt::Display for RegularCommunity {
+impl std::fmt::Display for Community {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
-            RegularCommunity::NoExport => {
+            Community::NoExport => {
                 "no-export".to_string()
             }
-            RegularCommunity::NoAdvertise => {
+            Community::NoAdvertise => {
                 "no-advertise".to_string()
             }
-            RegularCommunity::NoExportSubConfed => {
+            Community::NoExportSubConfed => {
                 "no-export-sub-confed".to_string()
             }
-            RegularCommunity::Custom(asn, value) => {
+            Community::Custom(asn, value) => {
                 format!("{}:{}", asn, value)
             }
         }
@@ -213,22 +199,13 @@ impl std::fmt::Display for ExtendedCommunity {
             ExtendedCommunity::NonTransitiveOpaque(ec) => {
                 format!("{}:{}:{}", ec.ec_type, ec.ec_subtype, bytes_to_string(&ec.value))
             }
+            ExtendedCommunity::Ipv6AddressSpecific(ec) => {
+                format!("{}:{}:{}:{}", ec.ec_type, ec.ec_subtype, ec.global_administrator, bytes_to_string(&ec.local_administrator))
+            }
             ExtendedCommunity::Raw(ec) => {
                 format!("{}", bytes_to_string(ec))
             }
         })
-    }
-}
-
-impl std::fmt::Display for Community {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let string = match self {
-            Community::RegularCommunity(c) => {c.to_string()}
-            Community::ExtendedCommunity(c) => {c.to_string()}
-            Community::Ipv6SpecificExtendedCommunity(c) => {c.to_string()}
-            Community::LargeCommunity(c) => {c.to_string()}
-        };
-        write!(f, "{}", string)
     }
 }
 
@@ -246,9 +223,6 @@ macro_rules! impl_serialize {
     }
 }
 
-impl_serialize!(RegularCommunity);
+impl_serialize!(Community);
 impl_serialize!(ExtendedCommunity);
 impl_serialize!(LargeCommunity);
-impl_serialize!(Ipv6AddressSpecificExtendedCommunity);
-
-impl_serialize!(Community);

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -42,6 +42,26 @@ pub struct BgpElem {
     pub aggr_ip: Option<IpAddr>,
 }
 
+/// Reference version of the [BgpElem] struct.
+#[derive(Debug, Clone, Serialize)]
+pub struct BgpElemRef<'a> {
+    pub timestamp: &'a f64,
+    pub elem_type: &'a ElemType,
+    pub peer_ip: &'a IpAddr,
+    pub peer_asn: &'a Asn,
+    pub prefix: &'a NetworkPrefix,
+    pub next_hop: &'a Option<IpAddr>,
+    pub as_path: &'a Option<AsPath>,
+    pub origin_asns: &'a Option<Vec<Asn>>,
+    pub origin: &'a Option<Origin>,
+    pub local_pref: &'a Option<u32>,
+    pub med: &'a Option<u32>,
+    pub communities: &'a Option<Vec<Community>>,
+    pub atomic: &'a Option<AtomicAggregate>,
+    pub aggr_asn: &'a Option<Asn>,
+    pub aggr_ip: &'a Option<IpAddr>,
+}
+
 impl Default for BgpElem {
     fn default() -> Self {
         BgpElem {

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -64,15 +64,13 @@ impl Default for BgpElem {
     }
 }
 
-#[inline(always)]
-pub fn option_to_string<T>(o: &Option<T>) -> String
-    where
-        T: Display,
-{
-    if let Some(v) = o {
-        v.to_string()
-    } else {
-        String::new()
+macro_rules! option_to_string{
+    ($a:expr) => {
+        if let Some(v) = $a {
+            v.to_string()
+        } else {
+            String::new()
+        }
     }
 }
 
@@ -98,15 +96,15 @@ impl Display for BgpElem {
             &self.peer_ip,
             &self.peer_asn,
             &self.prefix,
-            option_to_string(&self.as_path),
-            option_to_string(&self.origin),
-            option_to_string(&self.next_hop),
-            option_to_string(&self.local_pref),
-            option_to_string(&self.med),
+            option_to_string!(&self.as_path),
+            option_to_string!(&self.origin),
+            option_to_string!(&self.next_hop),
+            option_to_string!(&self.local_pref),
+            option_to_string!(&self.med),
             option_to_string_communities(&self.communities),
-            option_to_string(&self.atomic),
-            option_to_string(&self.aggr_asn),
-            option_to_string(&self.aggr_ip),
+            option_to_string!(&self.atomic),
+            option_to_string!(&self.aggr_asn),
+            option_to_string!(&self.aggr_ip),
         );
         write!(f, "{}", format)
     }

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -36,7 +36,7 @@ pub struct BgpElem {
     pub origin: Option<Origin>,
     pub local_pref: Option<u32>,
     pub med: Option<u32>,
-    pub communities: Option<Vec<Community>>,
+    pub communities: Option<Vec<MetaCommunity>>,
     pub atomic: Option<AtomicAggregate>,
     pub aggr_asn: Option<Asn>,
     pub aggr_ip: Option<IpAddr>,
@@ -95,7 +95,7 @@ macro_rules! option_to_string{
 }
 
 #[inline(always)]
-pub fn option_to_string_communities(o: &Option<Vec<Community>>) -> String {
+pub fn option_to_string_communities(o: &Option<Vec<MetaCommunity>>) -> String {
     if let Some(v) = o {
         v.iter()
             .join(" ")

--- a/src/bgp/elem.rs
+++ b/src/bgp/elem.rs
@@ -56,7 +56,7 @@ pub struct BgpElemRef<'a> {
     pub origin: &'a Option<Origin>,
     pub local_pref: &'a Option<u32>,
     pub med: &'a Option<u32>,
-    pub communities: &'a Option<Vec<Community>>,
+    pub communities: &'a Option<Vec<MetaCommunity>>,
     pub atomic: &'a Option<AtomicAggregate>,
     pub aggr_asn: &'a Option<Asn>,
     pub aggr_ip: &'a Option<IpAddr>,

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -67,7 +67,7 @@ pub struct OptParam {
 #[derive(Debug, Clone, Serialize)]
 pub struct BgpUpdateMessage {
     pub withdrawn_prefixes: Vec<NetworkPrefix>,
-    pub attributes: Attributes,
+    pub attributes: Vec<Attribute>,
     pub announced_prefixes: Vec<NetworkPrefix>,
 }
 

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -8,10 +8,11 @@ pub use crate::bgp::attributes::*;
 pub use crate::bgp::elem::*;
 pub use crate::bgp::community::*;
 
+use serde::Serialize;
 use std::net::Ipv4Addr;
 use crate::network::*;
 
-#[derive(Debug, Primitive, Copy, Clone)]
+#[derive(Debug, Primitive, Copy, Clone, Serialize)]
 pub enum BgpMessageType {
     OPEN = 1,
     UPDATE = 2,
@@ -20,7 +21,7 @@ pub enum BgpMessageType {
 }
 
 // https://tools.ietf.org/html/rfc4271#section-4
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum BgpMessage{
     Open(BgpOpenMessage),
     Update(BgpUpdateMessage),
@@ -49,7 +50,7 @@ pub enum BgpMessage{
 ///  |                                                               |
 ///  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BgpOpenMessage {
     pub version: u8,
     pub asn: Asn,
@@ -58,26 +59,26 @@ pub struct BgpOpenMessage {
     pub opt_params: Vec<OptParam>
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct OptParam {
 
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BgpUpdateMessage {
     pub withdrawn_prefixes: Vec<NetworkPrefix>,
     pub attributes: Attributes,
     pub announced_prefixes: Vec<NetworkPrefix>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BgpNotificationMessage {
     pub error_code: u8,
     pub error_subcode: u8,
     pub data: Vec<u8>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BgpKeepAliveMessage {
 
 }

--- a/src/mrt/bgp4mp.rs
+++ b/src/mrt/bgp4mp.rs
@@ -1,10 +1,11 @@
 //! MRT BGP4MP structs
 use std::net::IpAddr;
+use serde::Serialize;
 use crate::bgp::BgpMessage;
 use crate::network::{Afi, Asn};
 
 /// BGP states enum.
-#[derive(Debug, Primitive, Copy, Clone)]
+#[derive(Debug, Primitive, Copy, Clone, Serialize)]
 pub enum BgpState {
     Idle = 1,
     Connect = 2,
@@ -15,7 +16,7 @@ pub enum BgpState {
 }
 
 /// BGP4MP message types.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum Bgp4Mp {
     Bgp4MpStateChange(Bgp4MpStateChange),
     Bgp4MpStateChangeAs4(Bgp4MpStateChange),
@@ -26,7 +27,7 @@ pub enum Bgp4Mp {
 }
 
 /// BGP4MP message subtypes.
-#[derive(Debug, Primitive, Copy, Clone)]
+#[derive(Debug, Primitive, Copy, Clone, Serialize)]
 pub enum Bgp4MpType {
     Bgp4MpStateChange = 0,
     Bgp4MpMessage = 1,
@@ -41,7 +42,7 @@ pub enum Bgp4MpType {
 }
 
 /// BGP4MP state change message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Bgp4MpStateChange {
     pub peer_asn: Asn,
     pub local_asn: Asn,
@@ -54,7 +55,7 @@ pub struct Bgp4MpStateChange {
 }
 
 /// BGP4MP state change message with 4-byte ASN.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Bgp4MpStateChangeAs4 {
     pub peer_asn: Asn,
     pub local_asn: Asn,
@@ -67,7 +68,7 @@ pub struct Bgp4MpStateChangeAs4 {
 }
 
 /// BGP4MP message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Bgp4MpMessage {
     pub peer_asn: Asn,
     pub local_asn: Asn,

--- a/src/mrt/mod.rs
+++ b/src/mrt/mod.rs
@@ -5,6 +5,7 @@ pub mod bgp4mp;
 
 pub use crate::mrt::bgp4mp::*;
 pub use crate::mrt::tabledump::*;
+use serde::Serialize;
 
 /// MrtRecord is a wrapper struct that contains a header and a message.
 ///
@@ -21,7 +22,7 @@ pub use crate::mrt::tabledump::*;
 ///
 /// See [CommonHeader] for the content in header, and [MrtMessage] for the
 /// message format.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct MrtRecord {
     pub common_header: CommonHeader,
     pub message: MrtMessage,
@@ -67,7 +68,7 @@ pub struct MrtRecord {
 ///   `BGP4MP_ET`
 ///
 /// [header-link]: https://datatracker.ietf.org/doc/html/rfc6396#section-2
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize)]
 pub struct CommonHeader {
     pub timestamp: u32,
     pub microsecond_timestamp: Option<u32>,
@@ -76,7 +77,7 @@ pub struct CommonHeader {
     pub length: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum MrtMessage {
     TableDumpMessage(TableDumpMessage),
     TableDumpV2Message(TableDumpV2Message),
@@ -105,7 +106,7 @@ pub enum MrtMessage {
 ///     48   OSPFv3
 ///     49   OSPFv3_ET
 /// ```
-#[derive(Debug, Primitive, Copy, Clone)]
+#[derive(Debug, Primitive, Copy, Clone, Serialize)]
 #[allow(non_camel_case_types)]
 pub enum EntryType {
     // START DEPRECATED

--- a/src/mrt/tabledump.rs
+++ b/src/mrt/tabledump.rs
@@ -3,9 +3,10 @@ use std::net::IpAddr;
 use std::collections::HashMap;
 use crate::bgp::attributes::Attributes;
 use crate::network::{Afi, Asn, NetworkPrefix, Safi};
+use serde::Serialize;
 
 /// TableDump message version 1
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TableDumpMessage {
     pub view_number: u16,
     pub sequence_number: u16,
@@ -18,7 +19,7 @@ pub struct TableDumpMessage {
 }
 
 /// TableDump message version 2 enum
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum TableDumpV2Message {
     PeerIndexTable(PeerIndexTable),
     RibAfiEntries(RibAfiEntries),
@@ -28,7 +29,7 @@ pub enum TableDumpV2Message {
 /// TableDump version 2 subtypes.
 ///
 /// <https://www.iana.org/assignments/mrt/mrt.xhtml#subtype-codes>
-#[derive(Debug, Primitive, Copy, Clone)]
+#[derive(Debug, Primitive, Copy, Clone, Serialize)]
 pub enum TableDumpV2Type{
     PeerIndexTable = 1,
     RibIpv4Unicast = 2,
@@ -73,7 +74,7 @@ pub enum TableDumpV2Type{
 ///        |         Entry Count           |  RIB Entries (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RibAfiEntries{
     pub sequence_number: u32,
     pub prefix: NetworkPrefix,
@@ -101,7 +102,7 @@ pub struct RibAfiEntries{
 ///        |         Entry Count           |  RIB Entries (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RibGenericEntries{
     pub sequence_number: u32,
     pub afi: Afi,
@@ -131,7 +132,7 @@ pub struct RibGenericEntries{
 ///        |                    BGP Attributes... (variable)
 ///        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct RibEntry {
     pub peer_index: u16,
     pub originated_time: u32,
@@ -149,7 +150,7 @@ pub struct RibEntry {
 ///    itself and includes full MRT record headers.  The RIB entry MRT
 ///    records MUST immediately follow the PEER_INDEX_TABLE MRT record.
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct PeerIndexTable{
     pub collector_bgp_id: u32,
     pub view_name_length: u16,
@@ -159,7 +160,7 @@ pub struct PeerIndexTable{
 }
 
 /// Peer struct.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Peer {
     pub peer_type: u8,
     pub peer_bgp_id: u32,

--- a/src/mrt/tabledump.rs
+++ b/src/mrt/tabledump.rs
@@ -1,9 +1,9 @@
 //! MRT table dump version 1 and 2 structs
 use std::net::IpAddr;
 use std::collections::HashMap;
-use crate::bgp::attributes::Attributes;
 use crate::network::{Afi, Asn, NetworkPrefix, Safi};
 use serde::Serialize;
+use crate::bgp::Attribute;
 
 /// TableDump message version 1
 #[derive(Debug, Clone, Serialize)]
@@ -15,7 +15,7 @@ pub struct TableDumpMessage {
     pub originated_time: u64,
     pub peer_address: IpAddr,
     pub peer_asn: Asn,
-    pub attributes: Attributes,
+    pub attributes: Vec<Attribute>,
 }
 
 /// TableDump message version 2 enum
@@ -136,7 +136,7 @@ pub struct RibGenericEntries{
 pub struct RibEntry {
     pub peer_index: u16,
     pub originated_time: u32,
-    pub attributes: Attributes
+    pub attributes: Vec<Attribute>
 }
 
 /// peer index table.

--- a/src/network.rs
+++ b/src/network.rs
@@ -15,14 +15,14 @@ use crate::err::BgpModelsError;
 /// The meta information includes:
 /// 1. `afi`: address family ([Afi]): IPv4 or IPv6,
 /// 2. `asn_len`: AS number length ([AsnLength]): 16 or 32 bits.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AddrMeta {
     pub afi: Afi,
     pub asn_len: AsnLength,
 }
 
 /// AS number length: 16 or 32 bits.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum AsnLength {
     Bits16,
     Bits32,
@@ -34,7 +34,7 @@ pub type Asn = u32;
 /// AFI -- Address Family Identifier
 ///
 /// https://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml
-#[derive(Debug, PartialEq, Primitive, Clone, Copy)]
+#[derive(Debug, PartialEq, Primitive, Clone, Copy, Serialize)]
 pub enum Afi {
     Ipv4 = 1,
     Ipv6 = 2,
@@ -43,7 +43,7 @@ pub enum Afi {
 /// SAFI -- Subsequent Address Family Identifier
 ///
 /// SAFI can be: Unicast, Multicast, or both.
-#[derive(Debug, PartialEq, Primitive, Clone, Copy)]
+#[derive(Debug, PartialEq, Primitive, Clone, Copy, Serialize)]
 pub enum Safi {
     Unicast = 1,
     Multicast = 2,
@@ -53,7 +53,7 @@ pub enum Safi {
 /// enum that represents the type of the next hop address.
 ///
 /// [NextHopAddress] is used when parsing for next hops in [Nlri].
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Serialize)]
 pub enum NextHopAddress {
     Ipv4(Ipv4Addr),
     Ipv6(Ipv6Addr),


### PR DESCRIPTION
This PR includes a number of changes:
- add `serde::Serialize` implementation to `MrtRecord` and all it's sub strcuts. This allows easy serialization of MrtRecords and BgpElems.
- Change data type of attributes to `Vec<Attribute>` instead of `Vec<(AttrType, Attribute)>` for clarity and ease of use
- Add `MetaCommunity` enum to represent any Community types. Also updated the serialization to add string prefixes to extended communities and large communities for ease of use.

Related milestone: https://github.com/bgpkit/bgpkit-parser/milestone/2