### PR TITLE
change peer index table's `collector_bgp_id` type from `u32` to `Ipv4Addr`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/src/mrt/tabledump.rs
+++ b/src/mrt/tabledump.rs
@@ -1,5 +1,5 @@
 //! MRT table dump version 1 and 2 structs
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::collections::HashMap;
 use crate::network::{Afi, Asn, NetworkPrefix, Safi};
 use serde::Serialize;
@@ -152,7 +152,7 @@ pub struct RibEntry {
 /// ```
 #[derive(Debug, Clone, Serialize)]
 pub struct PeerIndexTable{
-    pub collector_bgp_id: u32,
+    pub collector_bgp_id: Ipv4Addr,
     pub view_name_length: u16,
     pub view_name: String,
     pub peer_count: u16,


### PR DESCRIPTION
Thanks @dteach-rv's help on interpreting `PEER_INDEX_TABLE` for table dump v2 format.