### PR TITLE
implement ordering for `BgpElem` based on time and ip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/src/bgp/attributes.rs
+++ b/src/bgp/attributes.rs
@@ -415,18 +415,4 @@ mod tests {
         assert!(origins.is_some());
         assert_eq!(origins.unwrap(), vec![7,8]);
     }
-
-    #[test]
-    fn test_aspath_display() {
-        let aspath = AsPath{
-            segments: vec![AsPathSegment::AsSequence([1,2,3,5].to_vec())]
-        };
-        let mut paths = vec![];
-        for _ in 0..1000000{
-            paths.push(aspath.clone());
-        }
-        for p in paths{
-            p.to_string();
-        }
-    }
 }


### PR DESCRIPTION
This allow downstream consumers to order `BgpElem` objects by time and peer ip.