### PR TITLE
Support open optional params

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ RFCs. Here is a list of them:
 
 ### BGP
 - [X] [RFC 2042](https://datatracker.ietf.org/doc/html/rfc2042): Registering New BGP Attribute Types
+- [X] [RFC 3392](https://datatracker.ietf.org/doc/html/rfc3392): Capabilities Advertisement with BGP-4
 - [X] [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271): A Border Gateway Protocol 4 (BGP-4)
 - [X] [RFC 5065](https://datatracker.ietf.org/doc/html/rfc5065): Autonomous System Confederations for BGP
 - [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
 - [X] [RFC 7911](https://datatracker.ietf.org/doc/html/rfc7911): Advertisement of Multiple Paths in BGP (ADD-PATH)
+- [X] [RFC 9072](https://datatracker.ietf.org/doc/html/rfc9072): Extended Optional Parameters Length for BGP OPEN Message Updates
 
 ### MRT
 

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -76,9 +76,9 @@ pub enum ParamValue {
 /// <https://datatracker.ietf.org/doc/html/rfc3392>
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Capability {
-    code: u8,
-    len: u8,
-    value: Vec<u8>
+    pub code: u8,
+    pub len: u8,
+    pub value: Vec<u8>
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/bgp/mod.rs
+++ b/src/bgp/mod.rs
@@ -56,12 +56,29 @@ pub struct BgpOpenMessage {
     pub asn: Asn,
     pub hold_time: u16,
     pub sender_ip: Ipv4Addr,
+    pub extended_length: bool,
     pub opt_params: Vec<OptParam>
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct OptParam {
+    pub param_type: u8,
+    pub param_len: u16,
+    pub param_value: ParamValue,
+}
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum ParamValue {
+    Raw(Vec<u8>),
+    Capability(Capability)
+}
+
+/// <https://datatracker.ietf.org/doc/html/rfc3392>
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Capability {
+    code: u8,
+    len: u8,
+    value: Vec<u8>
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,12 @@ RFCs. Here is a list of them:
 
 ### BGP
 - [X] [RFC 2042](https://datatracker.ietf.org/doc/html/rfc2042): Registering New BGP Attribute Types
+- [X] [RFC 3392](https://datatracker.ietf.org/doc/html/rfc3392): Capabilities Advertisement with BGP-4
 - [X] [RFC 4271](https://datatracker.ietf.org/doc/html/rfc4271): A Border Gateway Protocol 4 (BGP-4)
 - [X] [RFC 5065](https://datatracker.ietf.org/doc/html/rfc5065): Autonomous System Confederations for BGP
 - [X] [RFC 6793](https://datatracker.ietf.org/doc/html/rfc6793): BGP Support for Four-Octet Autonomous System (AS) Number Space
 - [X] [RFC 7911](https://datatracker.ietf.org/doc/html/rfc7911): Advertisement of Multiple Paths in BGP (ADD-PATH)
+- [X] [RFC 9072](https://datatracker.ietf.org/doc/html/rfc9072): Extended Optional Parameters Length for BGP OPEN Message Updates
 
 ### MRT
 


### PR DESCRIPTION
This enables parsing Open messages' optional parameters (i.e. capabilities).