### PR TITLE
change `Asn` inner field `asn` to u32 from i32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgp-models"
-version = "0.7.0-alpha.3"
+version = "0.7.0-alpha.4"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"

--- a/src/network.rs
+++ b/src/network.rs
@@ -31,7 +31,7 @@ pub enum AsnLength {
 /// ASN -- Autonomous System Number
 #[derive(Debug, Clone, Serialize, Copy, Deserialize, Eq)]
 pub struct Asn {
-    pub asn: i32,
+    pub asn: u32,
     pub len: AsnLength,
 }
 
@@ -43,30 +43,36 @@ impl PartialEq for Asn {
 
 impl PartialEq<i32> for Asn {
     fn eq(&self, other: &i32) -> bool {
-        self.asn==*other
+        self.asn as i32==*other
     }
 }
 
 impl PartialEq<u32> for Asn {
     fn eq(&self, other: &u32) -> bool {
-        self.asn as u32==*other
+        self.asn==*other
     }
 }
 
 impl From<u32> for Asn {
     fn from(v: u32) -> Self {
-        Asn{asn:v as i32, len: AsnLength::Bits32}
+        Asn{asn:v, len: AsnLength::Bits32}
     }
 }
 
 impl From<i32> for Asn {
     fn from(v: i32) -> Self {
-        Asn{asn:v, len: AsnLength::Bits32}
+        Asn{asn:v as u32, len: AsnLength::Bits32}
     }
 }
 
 impl Into<i32> for Asn {
     fn into(self) -> i32 {
+        self.asn as i32
+    }
+}
+
+impl Into<u32> for Asn {
+    fn into(self) -> u32 {
         self.asn
     }
 }


### PR DESCRIPTION
a negative value does not make sense as AS number, and in some cases, the AS number exceeds the max value of i32 (e.g. in some RIS Live messages).